### PR TITLE
Update version of docker images in K8s present in GAR

### DIFF
--- a/deploy/kubernetes/manifests/01-carts-dep.yaml
+++ b/deploy/kubernetes/manifests/01-carts-dep.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
       - name: carts
-        image: weaveworksdemos/carts:0.4.8
+        image: europe-west3-docker.pkg.dev/cnpe-blue/sockshop/carts:latest
         env:
          - name: JAVA_OPTS
            value: -Xms64m -Xmx128m -XX:+UseG1GC -Djava.security.egd=file:/dev/urandom -Dspring.zipkin.enabled=false

--- a/deploy/kubernetes/manifests/09-front-end-dep.yaml
+++ b/deploy/kubernetes/manifests/09-front-end-dep.yaml
@@ -23,8 +23,7 @@ spec:
     spec:
       containers:
       - name: front-end
-        # image: weaveworksdemos/front-end:0.3.12
-        image: jmgoyesc/dsp-front-end
+        image: europe-west3-docker.pkg.dev/cnpe-blue/sockshop/front-end:latest
         resources:
           limits:
             cpu: 300m

--- a/deploy/kubernetes/manifests/11-orders-dep.yaml
+++ b/deploy/kubernetes/manifests/11-orders-dep.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
       - name: orders
-        image: weaveworksdemos/orders:0.4.7
+        image: europe-west3-docker.pkg.dev/cnpe-blue/sockshop/orders:latest
         env:
          - name: JAVA_OPTS
            value: -Xms64m -Xmx128m -XX:+UseG1GC -Djava.security.egd=file:/dev/urandom -Dspring.zipkin.enabled=false

--- a/deploy/kubernetes/manifests/17-queue-master-dep.yaml
+++ b/deploy/kubernetes/manifests/17-queue-master-dep.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
       - name: queue-master
-        image: weaveworksdemos/queue-master:0.3.1
+        image: europe-west3-docker.pkg.dev/cnpe-blue/sockshop/queue-master:latest
         env:
          - name: JAVA_OPTS
            value: -Xms64m -Xmx128m -XX:+UseG1GC -Djava.security.egd=file:/dev/urandom -Dspring.zipkin.enabled=false

--- a/deploy/kubernetes/manifests/23-shipping-dep.yaml
+++ b/deploy/kubernetes/manifests/23-shipping-dep.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
       - name: shipping
-        image: weaveworksdemos/shipping:0.4.8
+        image: europe-west3-docker.pkg.dev/cnpe-blue/sockshop/shipping:latest
         env:
          - name: ZIPKIN
            value: zipkin.jaeger.svc.cluster.local


### PR DESCRIPTION
Update the following images inside the Kubernetes manifests, to use those from Google Artifact Registry:
- carts
- front-end
- orders
- queue-master
- shipping